### PR TITLE
Add the vulnerability via REST API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:php7.1-apache
+FROM wordpress:4.7.1
 
 COPY ./otherz /var/www/html/
 COPY ./plugins /var/www/html/wp-content/plugins


### PR DESCRIPTION
As I would like to try the vulnerability via REST API, ﻿﻿specify an old WordPress version.

WPScan Output is following:

>  | [!] Title: WordPress 4.7.0-4.7.1 - Unauthenticated Page/Post Content Modification via REST API
>  |     Fixed in: 4.7.2
>  |     References:
>  |      - https://wpvulndb.com/vulnerabilities/8734
>  |      - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-1001000
>  |      - https://blog.sucuri.net/2017/02/content-injection-vulnerability-wordpress-rest-api.html
>  |      - https://blogs.akamai.com/2017/02/wordpress-web-api-vulnerability.html
>  |      - https://gist.github.com/leonjza/2244eb15510a0687ed93160c623762ab
>  |      - https://github.com/WordPress/WordPress/commit/e357195ce303017d517aff944644a7a1232926f7
>  |      - https://www.rapid7.com/db/modules/auxiliary/scanner/http/wordpress_content_injection